### PR TITLE
fix humble not installing anymore

### DIFF
--- a/ros2_install_humble.sh
+++ b/ros2_install_humble.sh
@@ -154,6 +154,14 @@ case "$answer" in
 ;;
 esac
 echo "#######################################################################################################################"
+echo ""
+echo ">>>  {Starting ROS installation, this will take about 20 min. It will depends on your internet  connection}"
+echo ""
+sudo apt-get install -y ros-${name_ros_distro}-${package_type} 
+sudo apt install -y ros-dev-tools
+echo ""
+echo ""
+echo "#######################################################################################################################"
 echo ">>> {Step 6: Setting ROS Environment, This will add ROS environment to .bashrc.}" 
 echo ">>> { After adding this, you can able to access ROS commands in terminal}"
 echo ""


### PR DESCRIPTION
The apt install lines were removed in https://github.com/runtimerobotics/ros2_oneline_install/commit/365d6f617beaa3426d794ef9bf2772f714275903#diff-f63a4415320fcfb4e016081c9d71195ad9a20fa9361e686a7a712ade723b9078L140-L147 